### PR TITLE
Fix getFieldName helper

### DIFF
--- a/packages/cli/src/lib/parserHelpers/getFieldName.test.ts
+++ b/packages/cli/src/lib/parserHelpers/getFieldName.test.ts
@@ -1,0 +1,15 @@
+import { getFieldName } from './getFieldName';
+
+describe('getFieldName', () => {
+  it('should return username when pattern contains username', () => {
+    expect(getFieldName(/username/i)).toBe('username');
+  });
+
+  it('should return email when pattern contains email', () => {
+    expect(getFieldName(/email|mail/i)).toBe('email');
+  });
+
+  it('should return text when pattern does not contain known fields', () => {
+    expect(getFieldName(/random/i)).toBe('text');
+  });
+});

--- a/packages/cli/src/lib/parserHelpers/getFieldName.ts
+++ b/packages/cli/src/lib/parserHelpers/getFieldName.ts
@@ -1,7 +1,11 @@
 export function getFieldName(pattern: RegExp): string {
-  const match = pattern.exec(pattern.toString());
-  if (match && match[1]) {
-    return match[1].trim();
-  }
-  return '';
-} 
+  const src = pattern.source.toLowerCase();
+  if (src.includes('username')) return 'username';
+  if (src.includes('password')) return 'password';
+  if (src.includes('email')) return 'email';
+  if (src.includes('name')) return 'name';
+  if (src.includes('phone')) return 'phone';
+  if (src.includes('address')) return 'address';
+  if (src.includes('search')) return 'search';
+  return 'text';
+}


### PR DESCRIPTION
## Summary
- correct `getFieldName` implementation in CLI parser helpers
- add unit test for `getFieldName`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840ba40ed34832784eaa4835ea8ecf5