### PR TITLE
Fix empty state button alignment

### DIFF
--- a/frontend/src/pages/notes/NotesPage.tsx
+++ b/frontend/src/pages/notes/NotesPage.tsx
@@ -253,7 +253,7 @@ export const NotesPage: React.FC = () => {
                     </div>
                 ) : (
                     !isLoadingNotes && !notesError && ( // Ensure error isn't also shown
-                        <div className="text-center py-16 bg-slate-800/40 backdrop-blur-sm rounded-lg shadow-md">
+                        <div className="flex flex-col items-center justify-center text-center py-16 min-h-[60vh] bg-slate-800/40 backdrop-blur-sm rounded-lg shadow-md">
                             <BookOpenIcon className="h-20 w-20 text-slate-500 mx-auto mb-6" />
                             <h3 className="text-2xl font-semibold text-slate-300">No Notes Yet</h3>
                             <p className="text-slate-400 mt-3 max-w-md mx-auto">

--- a/frontend/src/pages/snippets/SnippetsPage.tsx
+++ b/frontend/src/pages/snippets/SnippetsPage.tsx
@@ -256,7 +256,7 @@ export const SnippetsPage: React.FC = () => {
                     </div>
                 ) : (
                      !isLoadingSnippets && !snippetsError && (
-                        <div className="text-center py-16 bg-slate-800/40 backdrop-blur-sm rounded-lg shadow-md">
+                        <div className="flex flex-col items-center justify-center text-center py-16 min-h-[60vh] bg-slate-800/40 backdrop-blur-sm rounded-lg shadow-md">
                             <CodeBracketSquareIcon className="h-20 w-20 text-slate-500 mx-auto mb-6" />
                             <h3 className="text-2xl font-semibold text-slate-300">No Snippets Here</h3>
                             <p className="text-slate-400 mt-3 max-w-md mx-auto">


### PR DESCRIPTION
## Summary
- center empty state containers on Notes and Snippets pages

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6840c3dcbdd083278bb085e2bc6b0523