### PR TITLE
Implement rules reaction promotion

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -10,3 +10,4 @@ LABNEX_FRONTEND_URL=http://localhost:5173
 LABNEX_BOT_SERVICE_ACCOUNT_JWT=your_bot_service_account_jwt_here
 DISCORD_BOT_TOKEN=your_discord_bot_token_here
 DISCORD_CLIENT_ID=your_discord_client_id_here
+RULES_MESSAGE_ID=rules_message_id_here

--- a/backend/src/bots/labnexAI/events/messageReactionAdd.ts
+++ b/backend/src/bots/labnexAI/events/messageReactionAdd.ts
@@ -1,0 +1,28 @@
+import { MessageReaction, User } from 'discord.js';
+
+const RULES_MESSAGE_ID = process.env.RULES_MESSAGE_ID;
+
+export async function handleMessageReactionAddEvent(reaction: MessageReaction, user: User) {
+  if (user.bot) return;
+  if (!reaction.message.guild) return;
+  if (!RULES_MESSAGE_ID) {
+    console.warn('[messageReactionAdd] RULES_MESSAGE_ID not set.');
+    return;
+  }
+  if (reaction.message.id !== RULES_MESSAGE_ID) return;
+  if (reaction.emoji.name !== '✅') return;
+
+  try {
+    const member = await reaction.message.guild.members.fetch(user.id);
+    const memberRole = reaction.message.guild.roles.cache.find(r => r.name === 'Member');
+    const waitlistRole = reaction.message.guild.roles.cache.find(r => r.name === 'Waitlist');
+
+    if (memberRole) await member.roles.add(memberRole);
+    if (waitlistRole) await member.roles.remove(waitlistRole);
+
+    console.log(`🎉 ${user.tag} accepted rules and became a Member.`);
+  } catch (err) {
+    console.error(`❌ Role update failed for ${user.tag}:`, err);
+  }
+}
+

--- a/backend/src/bots/labnexAI/labnexAI.bot.ts
+++ b/backend/src/bots/labnexAI/labnexAI.bot.ts
@@ -174,6 +174,7 @@ client.once(Events.ClientReady, readyClient => {
 import { handleInteractionCreateEvent, updateInteractionCounters } from './events/interactionCreateHandler';
 import { handleMessageCreateEvent } from './events/messageCreateHandler';
 import { handleGuildMemberAddEvent } from './events/guildMemberAdd';
+import { handleMessageReactionAddEvent } from './events/messageReactionAdd';
 
 //**********************************************************************
 // SLASH COMMAND (INTERACTION) HANDLER
@@ -200,6 +201,13 @@ client.on(Events.MessageCreate, async message => {
 client.on(Events.GuildMemberAdd, async member => {
     console.log(`[labnexAI.bot.ts] Event: GuildMemberAdd - ${member.user.tag} joined ${member.guild.name}`);
     await handleGuildMemberAddEvent(member);
+});
+
+//**********************************************************************
+// REACTION TO RULES MESSAGE HANDLER
+//**********************************************************************
+client.on(Events.MessageReactionAdd, async (reaction, user) => {
+    await handleMessageReactionAddEvent(reaction, user);
 });
 
 // Bot login


### PR DESCRIPTION
## Summary
- add `RULES_MESSAGE_ID` env var example
- grant Member role when reacting to rules
- wire reaction handler into Labnex AI bot

## Testing
- `npm test --silent` *(fails: jest not found)*
- `npm run lint --silent` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6841c37909948327bc422076c7229a12