### PR TITLE
Add reaction role assignment handler

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -10,3 +10,4 @@ LABNEX_FRONTEND_URL=http://localhost:5173
 LABNEX_BOT_SERVICE_ACCOUNT_JWT=your_bot_service_account_jwt_here
 DISCORD_BOT_TOKEN=your_discord_bot_token_here
 DISCORD_CLIENT_ID=your_discord_client_id_here
+ROLE_ASSIGN_MESSAGE_ID=your_get_started_message_id_here

--- a/backend/src/bots/labnexAI/events/messageReactionAdd.ts
+++ b/backend/src/bots/labnexAI/events/messageReactionAdd.ts
@@ -1,0 +1,33 @@
+import { MessageReaction, PartialMessageReaction, User, PartialUser } from 'discord.js';
+
+export async function handleMessageReactionAddEvent(
+  reaction: MessageReaction | PartialMessageReaction,
+  user: User | PartialUser
+) {
+  if (user.bot) return;
+
+  const roleMessageId = process.env.ROLE_ASSIGN_MESSAGE_ID;
+  if (!roleMessageId) {
+    console.warn('[messageReactionAdd.ts] ROLE_ASSIGN_MESSAGE_ID not set');
+    return;
+  }
+
+  try {
+    if (reaction.partial) await reaction.fetch();
+    if (reaction.message.id !== roleMessageId) return;
+    const guild = reaction.message.guild;
+    if (!guild) return;
+    const member = await guild.members.fetch(user.id);
+    const emoji = reaction.emoji.name;
+
+    if (emoji === '🔽') {
+      const devRole = guild.roles.cache.find(r => r.name === 'Developer');
+      if (devRole) await member.roles.add(devRole);
+    } else if (emoji === '🧪') {
+      const testerRole = guild.roles.cache.find(r => r.name === 'Tester');
+      if (testerRole) await member.roles.add(testerRole);
+    }
+  } catch (err) {
+    console.error(`\u274C Failed to assign Developer/Tester role to ${user.tag}:`, err);
+  }
+}

--- a/backend/src/bots/labnexAI/labnexAI.bot.ts
+++ b/backend/src/bots/labnexAI/labnexAI.bot.ts
@@ -103,9 +103,10 @@ const client = new Client({
         GatewayIntentBits.GuildMessages,
         GatewayIntentBits.MessageContent,
         GatewayIntentBits.DirectMessages,
-        GatewayIntentBits.GuildMembers
+        GatewayIntentBits.GuildMembers,
+        GatewayIntentBits.GuildMessageReactions
     ],
-    partials: [Partials.Channel],
+    partials: [Partials.Channel, Partials.Message, Partials.Reaction],
 });
 console.log('[labnexAI.bot.ts] Discord client initialized.');
 
@@ -174,6 +175,7 @@ client.once(Events.ClientReady, readyClient => {
 import { handleInteractionCreateEvent, updateInteractionCounters } from './events/interactionCreateHandler';
 import { handleMessageCreateEvent } from './events/messageCreateHandler';
 import { handleGuildMemberAddEvent } from './events/guildMemberAdd';
+import { handleMessageReactionAddEvent } from './events/messageReactionAdd';
 
 //**********************************************************************
 // SLASH COMMAND (INTERACTION) HANDLER
@@ -192,6 +194,13 @@ client.on(Events.MessageCreate, async message => {
     const counters = await handleMessageCreateEvent(message, client, messagesReceivedFromDiscord, messagesSentToUser);
     messagesReceivedFromDiscord = counters.updatedMessagesReceived;
     messagesSentToUser = counters.updatedMessagesSent;
+});
+
+//**********************************************************************
+// REACTION ROLE HANDLER
+//**********************************************************************
+client.on(Events.MessageReactionAdd, async (reaction, user) => {
+    await handleMessageReactionAddEvent(reaction, user);
 });
 
 //**********************************************************************


### PR DESCRIPTION
## Summary
- allow assigning roles in #get-started via reactions
- enable reaction event intents and partials
- document ROLE_ASSIGN_MESSAGE_ID in env example

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841c3a3d9f8832789058a0269de7651