### PR TITLE
Add sendroleselect Discord command

### DIFF
--- a/backend/src/bots/labnexAI/commands/sendroleselect.ts
+++ b/backend/src/bots/labnexAI/commands/sendroleselect.ts
@@ -1,0 +1,51 @@
+import {
+  SlashCommandBuilder,
+  CommandInteraction,
+  EmbedBuilder,
+  PermissionsBitField
+} from 'discord.js';
+
+export const data = new SlashCommandBuilder()
+  .setName('sendroleselect')
+  .setDescription('Posts the role selection embed (Developer / Tester) with emoji reactions.')
+  .setDefaultMemberPermissions(PermissionsBitField.Flags.Administrator)
+  .setDMPermission(false);
+
+export async function execute(interaction: CommandInteraction<'cached'>) {
+  const roleEmbed = new EmbedBuilder()
+    .setTitle("🎭 Choose Your Role")
+    .setColor(0x00BFFF)
+    .setDescription(
+      "Welcome to the Labnex closed beta!\n\n" +
+      "React to this message to choose your role:\n\n" +
+      "🔽 **Developer** — building and submitting projects\n" +
+      "🧪 **Tester** — helping test and report bugs\n\n" +
+      "👉 You may choose one or both!"
+    )
+    .setFooter({ text: "Your role helps us match you with the right tools and channels." });
+
+  try {
+    const sentMessage = await interaction.channel?.send({ embeds: [roleEmbed] });
+
+    if (!sentMessage) {
+      await interaction.reply({ content: "❌ Failed to send role selector message.", ephemeral: true });
+      return;
+    }
+
+    await sentMessage.react('🔽');
+    await sentMessage.react('🧪');
+
+    console.log(`🆔 Role Selection Message ID: ${sentMessage.id}`);
+    await interaction.reply({
+      content: `✅ Role selector posted successfully in <#${sentMessage.channel.id}>.\nMessage ID: \`${sentMessage.id}\`\n\nAdd this to your .env as \`ROLE_ASSIGN_MESSAGE_ID\`.`,
+      ephemeral: true
+    });
+  } catch (error) {
+    console.error(`❌ Error executing /sendroleselect:`, error);
+    if (!interaction.replied && !interaction.deferred) {
+      await interaction.reply({ content: 'There was an error posting the role selector.', ephemeral: true });
+    } else {
+      await interaction.followUp({ content: 'There was an error posting the role selector.', ephemeral: true });
+    }
+  }
+}

--- a/backend/src/bots/labnexAI/deploy-commands.ts
+++ b/backend/src/bots/labnexAI/deploy-commands.ts
@@ -153,6 +153,10 @@ const commands = [
         .setDescription('Sends the Labnex welcome embed for new members.')
         .setDefaultMemberPermissions(PermissionsBitField.Flags.Administrator)
         .setDMPermission(false),
+    new SlashCommandBuilder().setName('sendroleselect')
+        .setDescription('Posts the role selection embed (Developer / Tester) with emoji reactions.')
+        .setDefaultMemberPermissions(PermissionsBitField.Flags.Administrator)
+        .setDMPermission(false),
 
 ].map(command => command.toJSON());
 

--- a/backend/src/bots/labnexAI/events/interactionCreateHandler.ts
+++ b/backend/src/bots/labnexAI/events/interactionCreateHandler.ts
@@ -18,6 +18,7 @@ import { execute as handleSendEmbedCommand } from '../commands/sendEmbedCommand'
 import { execute as handleSendRulesCommand } from '../commands/sendrules';
 import { execute as handleSendInfoCommand } from '../commands/sendinfo';
 import { execute as handleSendWelcomeCommand } from '../commands/sendwelcome';
+import { execute as handleSendRoleSelectCommand } from '../commands/sendroleselect';
 import { CreateTaskOptions, LabnexNote, LabnexSnippet } from '../types/labnexAI.types';
 import { getInteractionStringOption } from '../utils/discordHelpers';
 
@@ -170,6 +171,8 @@ export async function handleInteractionCreateEvent(
             await handleSendInfoCommand(interaction as CommandInteraction<'cached'>);
         } else if (commandName === 'sendwelcome') {
             await handleSendWelcomeCommand(interaction as CommandInteraction<'cached'>);
+        } else if (commandName === 'sendroleselect') {
+            await handleSendRoleSelectCommand(interaction as CommandInteraction<'cached'>);
         } else {
             console.log(`[interactionCreateHandler.ts] Unrecognized slash command: ${commandName}`);
             await slashCmdInteractionReply("Sorry, I don't recognize that command.", true);


### PR DESCRIPTION
## Summary
- add `/sendroleselect` slash command
- register command in deploy script
- handle command in interaction events

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6841cca4a5d08327ad91d255cb480d40